### PR TITLE
Add support for start time margin for events

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,7 @@ This extension adds the `[tribe-happening-now]` shortcode. The parameters that c
 * `quantity`: Max number of events to show (defaults to unlimited “-1”)
 * `title`: Title above event list
 * `url_title`: Title of event’s Website URL CTA
+* `start_margin`: Start time margin for live events. Uses PHP createFromDateString syntax. Examples: 30 minutes, 1 hour + 15 minutes, 2 hours
 
 == Installation ==
 
@@ -42,6 +43,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.2.0] 2020-09-?? =
+
+* Add start_margin shortcode parameter to set a start time margin. Example: [tribe-happening-now start_margin="30 minutes"]
 
 = [1.1.0] 2020-03-24 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -44,7 +44,7 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
-= [1.2.0] 2020-09-?? =
+= [1.2.0] 2020-09-15 =
 
 * Add start_margin shortcode parameter to set a start time margin. Example: [tribe-happening-now start_margin="30 minutes"]
 

--- a/src/Tribe/Shortcode.php
+++ b/src/Tribe/Shortcode.php
@@ -44,7 +44,7 @@ class Shortcode {
 		'url_title'         => null,
 		'hide_url'          => null,
 		'featured'          => null,
-    'start_margin'      => null,
+		'start_margin'      => null,
 	];
 
 	/**

--- a/src/Tribe/Shortcode.php
+++ b/src/Tribe/Shortcode.php
@@ -1,6 +1,7 @@
 <?php
 namespace Tribe\Extensions\EventsHappeningNow;
 
+use DateInterval;
 use Tribe\Events\Views\V2\Assets as Event_Assets;
 use Tribe\Events\Views\V2\Theme_Compatibility;
 use Tribe\Events\Views\V2\View;
@@ -43,6 +44,7 @@ class Shortcode {
 		'url_title'         => null,
 		'hide_url'          => null,
 		'featured'          => null,
+    'start_margin'      => null,
 	];
 
 	/**
@@ -278,6 +280,13 @@ class Shortcode {
 		if ( isset( $arguments['quantity'] ) ) {
 			$repository_args['posts_per_page'] = (int) $arguments['quantity'];
 		}
+
+    if ( isset( $arguments['start_margin'] ) ) {
+			$margin = DateInterval::createFromDateString( $arguments['start_margin'] );
+			$starts_before = clone $repository_args['starts_before'];
+			$starts_before->add( $margin );
+			$repository_args['starts_before'] = $starts_before;
+    }
 
 		return $repository_args;
 	}

--- a/src/views/happening-now.php
+++ b/src/views/happening-now.php
@@ -24,6 +24,7 @@ if ( empty( $events ) ) {
 }
 
 $happening_now_title = $shortcode_object->get_argument( 'title', __( 'Events Happening Now', 'tribe-ext-events-happening-now' ) );
+$start_margin = $shortcode_object->get_argument( 'start_margin' );
 
 $header_classes    = [ 'tribe-events-header' ];
 $wrapper_classes   = [ 'tribe-events-calendar-list', 'tribe-ext-events-happening-now' ];
@@ -50,6 +51,10 @@ $wrapper_classes[] = 1 < count( $events ) ? 'tribe-ext-events-happening-now--mul
 
 			<div class="tribe-ext-events-happening-now__title">
 				<h2 class="tribe-common-h6 tribe-common-h5--min-medium"><?php echo esc_html( $happening_now_title ); ?></h2>
+        <?php if ( $start_margin ) : ?>
+          <?php $happening_now_or_within = sprintf( esc_html__( '(or within the next %s)', 'tribe-ext-events-happening-now' ), $start_margin ); ?>
+          <p class="tribe-common-b2"><?php echo $happening_now_or_within; ?></p>
+        <?php endif; ?>
 			</div>
 
 			<?php foreach ( $events as $event ) : ?>


### PR DESCRIPTION
Add start_margin shortcode parameter to set a start time margin for events.
Uses PHP createFromDateString syntax: 30 minutes, 1 hour + 15 minutes, 2 hours
Example: [tribe-happening-now start_margin="30 minutes"]

Notes:
1) I thought about changing the setup_repository_args function, but could not figure out how to access the shortcode arguments from there.
2) I used the tribe-common-b2 class for the added paragraph in the view but I am not sure that is the correct class.
3) I thought about adding an end time option too but it seemed less useful.
